### PR TITLE
swizzleInstance static to prevent potential conflicts

### DIFF
--- a/NBCoreBluetoothAPIMisuseGuard.m
+++ b/NBCoreBluetoothAPIMisuseGuard.m
@@ -12,7 +12,7 @@
 
 #if DEBUG
 
-void swizzleInstance(Class class, SEL originalSelector, SEL swizzledSelector) {
+static void swizzleInstance(Class class, SEL originalSelector, SEL swizzledSelector) {
     Method originalMethod = class_getInstanceMethod(class, originalSelector);
     Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
     


### PR DESCRIPTION
In case any other files happen to define `swizzleInstance`.
